### PR TITLE
Add single file execution functionality

### DIFF
--- a/ece2035/package.json
+++ b/ece2035/package.json
@@ -30,6 +30,11 @@
         "icon": "$(play)"
       },
       {
+          "command": "ece2035.runFile",
+          "title": "Run RISCV File",
+          "icon": "$(play)"
+      },
+      {
         "command": "ece2035.debugTestCase",
         "title": "Debug RISCV Test Case",
         "icon": "$(debug-alt)"
@@ -130,6 +135,13 @@
       ]
     },
     "menus": {
+      "editor/title/run": [
+        {
+          "command": "ece2035.runFile",
+          "when": "editorLangId == riscv && resourceExtname == .asm",
+          "group": "navigation"
+        }
+      ],
       "view/item/context": [
         {
           "command": "ece2035.deleteTestCase",

--- a/ece2035/src/defaults.ts
+++ b/ece2035/src/defaults.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_LAUNCH_CONFIG = {
+  "type": "riscv-vm",
+  "request": "launch",
+  "name": "Run File",
+  "program": "${file}",
+};

--- a/ece2035/src/testcases/testCaseExplorer.ts
+++ b/ece2035/src/testcases/testCaseExplorer.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { TestCase } from './testCase';
 import * as path from 'path';
 import { TestCaseExecutor, TestCaseExecutionResult } from './testCaseExecution';
+import { getResolvedLaunchConfig } from '../utils';
 
 export class TestCasesManager implements vscode.TreeDataProvider<TestCase> {
     private _onDidChangeTreeData: vscode.EventEmitter<TestCase | undefined> = new vscode.EventEmitter<TestCase | undefined>();
@@ -241,7 +242,7 @@ export class TestCasesManager implements vscode.TreeDataProvider<TestCase> {
                 return;
             }
         }
-    
+
     }
 
     public reportUpdatedStatus(seed: string, status: string, stats: any) {
@@ -254,43 +255,4 @@ export class TestCasesManager implements vscode.TreeDataProvider<TestCase> {
             }
         }
     }
-}
-
-// Function to manually resolve workspace folder variables
-function resolveVariables(config: any, folder: any, file: any) {
-    // Regex to find VS Code variables e.g., ${workspaceFolder}
-    const variablePatternWS = /\$\{workspaceFolder\}/g;
-    const variablePatternFile = /\$\{file\}/g;
-
-    // escaping the folder and file path strings
-    const escapedFolder = folder.uri.fsPath.replace(/\\/g, '\\\\');
-    const escapedFile = file.fsPath.replace(/\\/g, '\\\\');
-
-    // Serialize the configuration object to a string
-    let configString = JSON.stringify(config);
-
-    // Replace all occurrences of ${workspaceFolder}
-    configString = configString.replace(variablePatternWS, escapedFolder);
-    configString = configString.replace(variablePatternFile, escapedFile);
-
-    // Parse it back to an object
-    return JSON.parse(configString);
-}
-
-// Function to get and resolve launch configurations
-function getResolvedLaunchConfig() {
-    // Access the workspace configuration for 'launch'
-    const launchConfig = vscode.workspace.getConfiguration('launch', vscode.workspace.workspaceFolders![0]);
-
-    // Get the configurations array from the 'launch' configuration
-    const configs = launchConfig['configurations'];
-
-    const currFile = vscode.window.activeTextEditor?.document.uri;
-
-    if (configs && Array.isArray(configs)) {
-        // Iterate through configurations
-        return configs.map(config => resolveVariables(config, vscode.workspace.workspaceFolders![0], currFile));
-    }
-
-    return [];
 }

--- a/ece2035/src/utils.ts
+++ b/ece2035/src/utils.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+
+export function getResolvedLaunchConfig() {
+  // Access the workspace configuration for 'launch'
+  const launchConfig = vscode.workspace.getConfiguration('launch', vscode.workspace.workspaceFolders![0]);
+
+  // Get the configurations array from the 'launch' configuration
+  const configs = launchConfig['configurations'];
+
+  const currFile = vscode.window.activeTextEditor?.document.uri;
+
+  if (configs && Array.isArray(configs)) {
+    // Iterate through configurations
+    return configs.map(config => resolveVariables(config, vscode.workspace.workspaceFolders![0], currFile));
+  }
+
+  return [];
+}
+
+// Function to manually resolve workspace folder variables
+function resolveVariables(config: any, folder: any, file: any) {
+    // Regex to find VS Code variables e.g., ${workspaceFolder}
+    const variablePatternWS = /\$\{workspaceFolder\}/g;
+    const variablePatternFile = /\$\{file\}/g;
+
+    // escaping the folder and file path strings
+    const escapedFolder = folder.uri.fsPath.replace(/\\/g, '\\\\');
+    const escapedFile = file.fsPath.replace(/\\/g, '\\\\');
+
+    // Serialize the configuration object to a string
+    let configString = JSON.stringify(config);
+
+    // Replace all occurrences of ${workspaceFolder}
+    configString = configString.replace(variablePatternWS, escapedFolder);
+    configString = configString.replace(variablePatternFile, escapedFile);
+
+    // Parse it back to an object
+    return JSON.parse(configString);
+}


### PR DESCRIPTION
# Overview
Adds single file execution functionality. Closes #7, where a more detailed description is provided. 

# Changes
- A play button will now appear when viewing a RISC-V assembly file, allowing it to be run without an explicit launch.json file. If a launch file is detected, it will override the default config (same behavior as before).
- Config retrieval code has been moved to a common utilities class
- Added `ece2035.runFile` command (also executable through command palette)