### PR TITLE
Add explicit boolean for using localEmulator

### DIFF
--- a/ece2035/package.json
+++ b/ece2035/package.json
@@ -182,12 +182,14 @@
       "title": "RISC-V",
       "properties": {
         "riscv.emulatorPath": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "default": null,
           "description": "(Optional) Specify an explicit emulator executable path to use for debugging."
+        },
+        "riscv.useLocalEmulator": {
+          "type": "boolean",
+          "default": false,
+          "description": "If selected, the emulator will attempt to use a local emulator executable as provided by emulatorPath."
         }
       }
     }

--- a/ece2035/src/extension.ts
+++ b/ece2035/src/extension.ts
@@ -27,7 +27,7 @@ var showingTestCase: TestCase | undefined;
 
 const configuration = vscode.workspace.getConfiguration("riscv");
 const emulatorPath: string = configuration.get("emulatorPath") || "";
-const useLocalEmulator = emulatorPath.length !== 0;
+const useLocalEmulator = configuration.get("useLocalEmulator") as boolean;
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed


### PR DESCRIPTION
- Added an explicit "useLocalEmulator" boolean setting for using a local emulator executable to easily switch between development/production